### PR TITLE
update positional argument in bip_utils

### DIFF
--- a/avaxpython/wallet/BIP44.py
+++ b/avaxpython/wallet/BIP44.py
@@ -62,4 +62,4 @@ class AVAXConf:
 
 Bip44AVAXMainNet = Bip44Coin(coin_conf  = AVAXConf,
                                 is_testnet = False,
-                                addr_fct   = P2PKH)
+                                addr_cls   = P2PKH)


### PR DESCRIPTION
Looks like in [v1.11.0 of bip_utils](https://github.com/ebellocchia/bip_utils/commit/41364d6a30c5419da544a21890ada9cbe5401da9)
**addr_fct** was renamed to **addr_cls**.

Since this was constructed as a positional argument the change broke it